### PR TITLE
Optimize Doom Emacs performance and startup time

### DIFF
--- a/config.el
+++ b/config.el
@@ -38,7 +38,7 @@
 ;; numbers are disabled. For relative line numbers, set this to `relative'.
 (setq display-line-numbers-type 'relative)
 (setq doom-font (font-spec :family "Hack" :size 20))
-(setq doom-variable-pitch-font (font-spec :family "Inter" :size 24))
+(setq doom-variable-pitch-font (font-spec :family "Alegreya" :size 24))
 (setq vterm-timer-delay 0.01
       vterm-shell "fish"
       vterm-buffer-name-string "vterm %s")
@@ -304,20 +304,20 @@
          age-default-recipient "~/.dotfiles/secrets/emacs/emacs.pub")
   (age-file-enable))
 
-(use-package! websocket
-  :after org-roam)
+;; (use-package! websocket
+;;   :after org-roam)
 
-(use-package! org-roam-ui
-  :after org-roam ;; or :after org
-  ;;         normally we'd recommend hooking orui after org-roam, but since org-roam does not have
-  ;;         a hookable mode anymore, you're advised to pick something yourself
-  ;;         if you don't care about startup time, use
-  ;;  :hook (after-init . org-roam-ui-mode)
-  :config
-  (setq org-roam-ui-sync-theme t
-        org-roam-ui-follow t
-        org-roam-ui-update-on-save t
-        org-roam-ui-open-on-start t))
+;; (use-package! org-roam-ui
+;;   :after org-roam ;; or :after org
+;;   ;;         normally we'd recommend hooking orui after org-roam, but since org-roam does not have
+;;   ;;         a hookable mode anymore, you're advised to pick something yourself
+;;   ;;         if you don't care about startup time, use
+;;   ;;  :hook (after-init . org-roam-ui-mode)
+;;   :config
+;;   (setq org-roam-ui-sync-theme t
+;;         org-roam-ui-follow t
+;;         org-roam-ui-update-on-save t
+;;         org-roam-ui-open-on-start t))
 
 (after! lsp-mode
   (setq lsp-pylsp-plugins-ruff-enabled t
@@ -337,7 +337,7 @@
                               '(:installVale :json-false
                                 :syncOnStartup :json-false))))
 
-)
+  )
 
 
 (after! dap-mode

--- a/custom.el
+++ b/custom.el
@@ -4,7 +4,8 @@
  ;; Your init file should contain only one such instance.
  ;; If there is more than one, they won't work right.
  '(safe-local-variable-values
-   '((gac-automatically-add-new-files-p t) (gac-automatically-push-p t))))
+   '((gac-automatically-add-new-files-p nil) (gac-automatically-push-p nil)
+     (gac-automatically-add-new-files-p t) (gac-automatically-push-p t))))
 (custom-set-faces
  ;; custom-set-faces was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.

--- a/init.el
+++ b/init.el
@@ -21,12 +21,12 @@
        ;;layout            ; auie,ctsrnm is the superior home row
 
        :completion
-       (company +childframe)      ; the ultimate code completion backend
+       ;; (company +childframe)      ; the ultimate code completion backend
        ;;helm              ; the *other* search engine for love and life
        ;;ido               ; the other *other* search engine...
        ;;ivy               ; a search engine for love and life
-       (vertico +icons +childframe)                 ; the search engine of the future
-       ;; (corfu +icons +orderless +dabbrev)
+       (vertico +icons)                 ; the search engine of the future
+       (corfu +icons +orderless +dabbrev)
 
        :ui
        ;;deft              ; notational velocity for Emacs
@@ -37,7 +37,7 @@
                                         ; 🙂
        hl-todo            ; highlight TODO/FIXME/NOTE/DEPRECATED/HACK/REVIEW
        indent-guides      ; highlighted indent columns
-       (ligatures +fira)  ; ligatures and symbols to make your code pretty again
+       ;; (ligatures +fira)  ; ligatures and symbols to make your code pretty again
        ;;minimap           ; show a map of the code on the side
        modeline    ; snazzy, Atom-inspired modeline, plus API
        ;;nav-flash         ; blink cursor line after big motions
@@ -47,7 +47,7 @@
        ;;tabs              ; a tab bar for Emacs
        ;;treemacs          ; a project drawer, like neotree but cooler
        ;;unicode           ; extended unicode support for various languages
-       (vc-gutter +pretty)    ; vcs diff in the fringe
+       (vc-gutter)    ; vcs diff in the fringe
        vi-tilde-fringe        ; fringe tildes to mark beyond EOB
        window-select          ; visually switch windows
        workspaces             ; tab emulation, persistence & separate workspaces
@@ -158,7 +158,7 @@
        ;;nim               ; python + lisp at the speed of c
        (nix +lsp)                       ; I hereby declare "nix geht mehr!"
        ;;ocaml             ; an objective camel
-       (org +roam2 +pandoc +noter +pretty +dragndrop)
+       (org +roam2 +pandoc +noter +dragndrop +pretty)
        ;;php               ; perl's insecure younger brother
        ;;plantuml          ; diagrams for confusing people more
        ;;purescript        ; javascript, but functional

--- a/packages.el
+++ b/packages.el
@@ -43,18 +43,18 @@
 (package! org-super-agenda)
 (package! org-ql)
 (package! olivetti)
-(package! org-modern)
+;; (package! org-modern)
 (package! fzf)
 (package! hyperbole :disable t)
 (package! shrface :disable t)
 (package! consult-org-roam)
 (package! age)
 (unpin! org-roam)
-(package! org-roam-ui)
+;; (package! org-roam-ui)
 (package! git-auto-commit-mode)
 (package! org-download)
-(package! elisp-dev-mcp)
-
+;; (package! elisp-dev-mcp)
+(package! just-mode)
 ;; Doom's packages are pinned to a specific commit and updated from release to
 ;; release. The `unpin!' macro allows you to unpin single packages...
 ;; (unpin! pinned-package)


### PR DESCRIPTION
## Summary
- Switch from Company to Corfu for faster, more modern code completion
- Remove resource-intensive UI features (childframes, ligatures, pretty vc-gutter)
- Disable startup-heavy packages (org-roam-ui, websocket, elisp-dev-mcp)

## Changes Made

### Performance Optimizations
- **Code Completion**: Migrated from Company to Corfu with dabbrev support for lighter, faster completion
- **UI Simplification**: Removed childframe from vertico to reduce rendering overhead
- **Visual Features**: Disabled ligatures and pretty vc-gutter for better performance
- **Package Cleanup**: Commented out org-roam-ui and its websocket dependency to improve startup time

### Other Updates
- Changed variable pitch font from Inter to Alegreya
- Added just-mode package for Justfile support
- Merged latest changes from main branch including hugo sidenotes support

## Test Plan
- [x] Emacs starts successfully with new configuration
- [x] Code completion works with Corfu
- [x] All essential features remain functional
- [x] Noticeable improvement in startup time
- [ ] Test on different machines/environments

🤖 Generated with [Claude Code](https://claude.ai/code)